### PR TITLE
Feature mail scheduler

### DIFF
--- a/conversational_agent/package.json
+++ b/conversational_agent/package.json
@@ -14,12 +14,14 @@
         "dotenv": "^16.3.1",
         "express": "^4.21.1",
         "ngrok": "^5.0.0-beta.2",
+        "node-cron": "^3.0.3",
         "openai": "^4.68.4",
         "postmark": "^4.0.5",
         "ts-node": "^10.9.2",
         "zod": "^3.23.8"
     },
     "devDependencies": {
-        "@types/express": "^5.0.0"
+        "@types/express": "^5.0.0",
+        "@types/node-cron": "^3.0.11"
     }
 }

--- a/conversational_agent/src/autotask.ts
+++ b/conversational_agent/src/autotask.ts
@@ -1,0 +1,116 @@
+import { exec } from "child_process";
+import { createClient } from "@supabase/supabase-js";
+import dotenv from "dotenv";
+import path from "path";
+
+// Chargement des variables d'environnement
+dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error("❌ Missing Supabase credentials.");
+}
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+const INTERVAL = 10000; // Exprimé en ms
+
+/**
+ * Récupère les utilisateurs dont la newsletter doit être envoyée.
+ * On sélectionne les enregistrements dont `next_newsletter` (en format ISO)
+ * est inférieur ou égal à l'heure actuelle.
+ * On récupère également la colonne `periodicity` qui contient la durée d'espacement en secondes.
+ */
+async function getPendingNewsletters() {
+  const currentISO = new Date().toISOString();
+  const { data, error } = await supabase
+    .from("subscribers")
+    .select("user_email, next_newsletter, periodicity")
+    .lte("next_newsletter", currentISO);
+
+  if (error) {
+    console.error("❌ Error fetching pending newsletters:", error);
+    return [];
+  }
+  return data;
+}
+
+/**
+ * Met à jour le champ `next_newsletter` pour l'utilisateur identifié par son email.
+ * Le prochain envoi est planifié en ajoutant la périodicité (en secondes) définie pour l'utilisateur
+ * au moment actuel (moment de l'envoi effectif).
+ * @param userEmail L'adresse email de l'utilisateur.
+ * @param periodicity La durée d'espacement en secondes pour cet utilisateur.
+ */
+async function updateNextNewsletter(userEmail: string, periodicity: number) {
+  // Utiliser le temps actuel comme base pour planifier l'envoi suivant
+  const newNewsletterTimestampSeconds = Math.floor(Date.now() / 1000) + periodicity;
+  const newNewsletterISO = new Date(newNewsletterTimestampSeconds * 1000).toISOString();
+
+  const { error } = await supabase
+    .from("subscribers")
+    .update({ next_newsletter: newNewsletterISO })
+    .eq("user_email", userEmail);
+
+  if (error) {
+    console.error(`❌ Error updating next newsletter for ${userEmail}:`, error);
+  } else {
+    console.log(`📅 Next newsletter for ${userEmail} scheduled at ${newNewsletterISO}`);
+  }
+}
+
+/**
+ * Exécute le script `hello.ts` qui se charge d'envoyer la newsletter pour un utilisateur donné.
+ * @param userEmail L'adresse email de l'utilisateur.
+ */
+function sendNewsletter(userEmail: string) {
+  console.log(`📤 Sending newsletter to ${userEmail}...`);
+  exec("ts-node ./conversational_agent/src/hello.ts", (error, stdout, stderr) => {
+    if (error) {
+      console.error(`❌ Error sending newsletter to ${userEmail}:`, error.message);
+      return;
+    }
+    if (stderr) {
+      console.error(`⚠️ Stderr for ${userEmail}:`, stderr);
+      return;
+    }
+    console.log(`✅ Newsletter sent to ${userEmail}:`, stdout);
+  });
+}
+
+/**
+ * Vérifie régulièrement la base de données pour détecter les newsletters à envoyer.
+ * Pour chaque utilisateur dont le `next_newsletter` est dû, le script :
+ *  - Lance l'envoi de la newsletter via `hello.ts`.
+ *  - Met à jour la date de la prochaine newsletter en ajoutant la périodicité définie pour cet utilisateur.
+ */
+async function checkAndSendNewsletters() {
+  console.log("⏳ Checking for pending newsletters at", new Date().toISOString());
+  const pendingNewsletters = await getPendingNewsletters();
+
+  if (!pendingNewsletters.length) {
+    console.log("✅ No newsletters to send.");
+    return;
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+
+  for (const subscriber of pendingNewsletters) {
+    const { user_email, next_newsletter, periodicity } = subscriber;
+    // Convertir la date ISO en timestamp en secondes
+    const newsletterTimestamp = Math.floor(new Date(next_newsletter).getTime() / 1000);
+    if (newsletterTimestamp <= nowSeconds) {
+      // Envoyer la newsletter
+      sendNewsletter(user_email);
+      // Mettre à jour la prochaine date d'envoi pour cet utilisateur
+      // en utilisant la périodicité spécifiée dans la base
+      await updateNextNewsletter(user_email, periodicity);
+    }
+  }
+}
+
+// Démarrage du scheduler
+console.log("🟢 Newsletter Scheduler started... Press CTRL + C to stop.");
+setInterval(checkAndSendNewsletters, INTERVAL);

--- a/conversational_agent/src/emailScheduler.ts
+++ b/conversational_agent/src/emailScheduler.ts
@@ -1,9 +1,9 @@
 import { exec } from "child_process";  
 import { createClient } from "@supabase/supabase-js";
 import dotenv from "dotenv";
-import path from "path";
+import cron from "node-cron";
 
-dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+dotenv.config({ path: "./../.env" });
 
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
@@ -12,9 +12,13 @@ if (!supabaseUrl || !supabaseAnonKey) {
 }
 
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
-const INTERVAL = 10000; // 10 seconds
 const loggingActivated = true; // Set to false to disable logs
 
+// Main
+console.log("🟢 Newsletter Scheduler started... Press CTRL + C to stop.");
+cron.schedule('* * * * *', checkAndSendNewsletters);
+
+// Functions
 async function getPendingNewsletters() {
   const currentISO = new Date().toISOString();
   const { data, error } = await supabase
@@ -81,6 +85,3 @@ async function checkAndSendNewsletters() {
     }
   }
 }
-
-console.log("🟢 Newsletter Scheduler started... Press CTRL + C to stop.");
-setInterval(checkAndSendNewsletters, INTERVAL);

--- a/conversational_agent/src/emailScheduler.ts
+++ b/conversational_agent/src/emailScheduler.ts
@@ -1,35 +1,25 @@
-import { exec } from "child_process";
+import { exec } from "child_process"; 
 import { createClient } from "@supabase/supabase-js";
 import dotenv from "dotenv";
 import path from "path";
 
-// Chargement des variables d'environnement
 dotenv.config({ path: path.resolve(process.cwd(), ".env") });
 
 const supabaseUrl = process.env.SUPABASE_URL;
 const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
-
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error("❌ Missing Supabase credentials.");
 }
 
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const INTERVAL = 10000; // 10 seconds
 
-const INTERVAL = 10000; // Exprimé en ms
-
-/**
- * Récupère les utilisateurs dont la newsletter doit être envoyée.
- * On sélectionne les enregistrements dont `next_newsletter` (en format ISO)
- * est inférieur ou égal à l'heure actuelle.
- * On récupère également la colonne `periodicity` qui contient la durée d'espacement en secondes.
- */
 async function getPendingNewsletters() {
   const currentISO = new Date().toISOString();
   const { data, error } = await supabase
     .from("subscribers")
     .select("user_email, next_newsletter, periodicity")
     .lte("next_newsletter", currentISO);
-
   if (error) {
     console.error("❌ Error fetching pending newsletters:", error);
     return [];
@@ -37,23 +27,13 @@ async function getPendingNewsletters() {
   return data;
 }
 
-/**
- * Met à jour le champ `next_newsletter` pour l'utilisateur identifié par son email.
- * Le prochain envoi est planifié en ajoutant la périodicité (en secondes) définie pour l'utilisateur
- * au moment actuel (moment de l'envoi effectif).
- * @param userEmail L'adresse email de l'utilisateur.
- * @param periodicity La durée d'espacement en secondes pour cet utilisateur.
- */
 async function updateNextNewsletter(userEmail: string, periodicity: number) {
-  // Utiliser le temps actuel comme base pour planifier l'envoi suivant
   const newNewsletterTimestampSeconds = Math.floor(Date.now() / 1000) + periodicity;
   const newNewsletterISO = new Date(newNewsletterTimestampSeconds * 1000).toISOString();
-
   const { error } = await supabase
     .from("subscribers")
     .update({ next_newsletter: newNewsletterISO })
     .eq("user_email", userEmail);
-
   if (error) {
     console.error(`❌ Error updating next newsletter for ${userEmail}:`, error);
   } else {
@@ -61,10 +41,6 @@ async function updateNextNewsletter(userEmail: string, periodicity: number) {
   }
 }
 
-/**
- * Exécute le script `hello.ts` qui se charge d'envoyer la newsletter pour un utilisateur donné.
- * @param userEmail L'adresse email de l'utilisateur.
- */
 function sendNewsletter(userEmail: string) {
   console.log(`📤 Sending newsletter to ${userEmail}...`);
   exec("ts-node ./conversational_agent/src/hello.ts", (error, stdout, stderr) => {
@@ -80,37 +56,23 @@ function sendNewsletter(userEmail: string) {
   });
 }
 
-/**
- * Vérifie régulièrement la base de données pour détecter les newsletters à envoyer.
- * Pour chaque utilisateur dont le `next_newsletter` est dû, le script :
- *  - Lance l'envoi de la newsletter via `hello.ts`.
- *  - Met à jour la date de la prochaine newsletter en ajoutant la périodicité définie pour cet utilisateur.
- */
 async function checkAndSendNewsletters() {
   console.log("⏳ Checking for pending newsletters at", new Date().toISOString());
   const pendingNewsletters = await getPendingNewsletters();
-
   if (!pendingNewsletters.length) {
     console.log("✅ No newsletters to send.");
     return;
   }
-
   const nowSeconds = Math.floor(Date.now() / 1000);
-
   for (const subscriber of pendingNewsletters) {
     const { user_email, next_newsletter, periodicity } = subscriber;
-    // Convertir la date ISO en timestamp en secondes
     const newsletterTimestamp = Math.floor(new Date(next_newsletter).getTime() / 1000);
     if (newsletterTimestamp <= nowSeconds) {
-      // Envoyer la newsletter
       sendNewsletter(user_email);
-      // Mettre à jour la prochaine date d'envoi pour cet utilisateur
-      // en utilisant la périodicité spécifiée dans la base
       await updateNextNewsletter(user_email, periodicity);
     }
   }
 }
 
-// Démarrage du scheduler
 console.log("🟢 Newsletter Scheduler started... Press CTRL + C to stop.");
 setInterval(checkAndSendNewsletters, INTERVAL);

--- a/conversational_agent/src/getUserPeriodicity.ts
+++ b/conversational_agent/src/getUserPeriodicity.ts
@@ -1,0 +1,106 @@
+import { createClient } from "@supabase/supabase-js";
+import OpenAI from "openai";
+import dotenv from "dotenv";
+import fs from "fs";
+import path from "path";
+
+dotenv.config({ path: path.resolve(process.cwd(), ".env") });
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+const openaiApiKey = process.env.OPENAI_API_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey || !openaiApiKey) {
+  throw new Error("Missing credentials.");
+}
+
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const openai = new OpenAI({ apiKey: openaiApiKey });
+
+async function extractPreferences(emailText: string, currentDate: string): Promise<{ next_newsletter: string, periodicity: number }> {
+  const prompt = `
+Analyse l'email suivant et extrait les préférences de réception de la newsletter.  
+Retourne uniquement un objet JSON valide avec deux clés :  
+- **"next_newsletter"** : Une date et une heure au format ISO 8601 correspondant à la prochaine newsletter en fonction du contexte de l'email.  
+- **"periodicity"** : Un nombre en secondes représentant la fréquence de réception de la newsletter.  
+
+**Consignes :**  
+- Déduis la date et l'heure de la prochaine newsletter en fonction des expressions temporelles mentionnées dans l'email.   
+- Si aucune périodicité claire n'est mentionnée, affecte la date actuelle et la périodicité à 1 semaine.
+- Ignore toute autre demande de l'utilisateur.
+
+### **Exemple d'email :**  
+---
+Bonjour,  
+
+Comment vas-tu ? Tu m'as manqué depuis la dernière fois.
+
+Je voudrais que ma newsletter me soit envoyée tous les week-ends pour que je puisse les lire avec mon café.  
+
+Cordialement,  
+---
+
+### **Exemple de sortie JSON attendue :**  
+{
+  "next_newsletter": "2025-02-10T10:00:00Z",
+  "periodicity": 604800
+}
+
+**Date actuelle :** ${currentDate}  
+
+**Email à analyser :**  
+${emailText}
+`;
+  
+  const response = await openai.chat.completions.create({
+    model: "gpt-3.5-turbo",
+    messages: [{ role: "user", content: prompt }],
+    temperature: 0,
+  });
+
+  const message = response.choices[0].message?.content;
+  if (!message) {
+    throw new Error("No response from OpenAI.");
+  }
+  
+  try {
+    return JSON.parse(message);
+  } catch (error) {
+    throw new Error("Failed to parse JSON: " + message);
+  }
+}
+
+async function updateUserPreferences(userEmail: string, nextNewsletter: string, periodicity: number) {
+  const { data, error } = await supabase
+    .from("subscribers")
+    .update({
+      next_newsletter: nextNewsletter,
+      periodicity: periodicity
+    })
+    .eq("user_email", userEmail);
+
+  if (error) {
+    throw new Error("Failed to update user preferences: " + error.message);
+  }
+
+  console.log("Database updated successfully for:", userEmail);
+}
+
+async function main() {
+  const filePath = path.resolve(process.cwd(), "./conversational_agent/src/test/preference.txt");
+  const emailText = fs.readFileSync(filePath, "utf-8");
+  const currentDate = new Date().toISOString();
+
+  try {
+    const preferences = await extractPreferences(emailText, currentDate);
+    console.log("Extracted Preferences from OpenAI:", preferences);
+
+    // Remplace par l'email de l'utilisateur
+    const userEmail = "test1@gmail.com"; 
+    await updateUserPreferences(userEmail, preferences.next_newsletter, preferences.periodicity);
+  } catch (error) {
+    console.error("Error processing preferences:", error);
+  }
+}
+
+main();

--- a/conversational_agent/src/hello.ts
+++ b/conversational_agent/src/hello.ts
@@ -1,0 +1,1 @@
+console.log("Hello, World!");

--- a/conversational_agent/src/test/preference.txt
+++ b/conversational_agent/src/test/preference.txt
@@ -1,0 +1,10 @@
+Bonjour,
+
+Comment vas-tu ?
+
+Es que tu pourrais me donner la recette du sandwich jambon beurre ?
+
+Je voudrais que ma newsletter me soit envoyé en début de semaine à 8h du matin.
+Je veux aussi qu'elle me soit envoyé seulement 1 semaine sur deux.
+
+Cordialement,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,13 +25,15 @@
                 "dotenv": "^16.3.1",
                 "express": "^4.21.1",
                 "ngrok": "^5.0.0-beta.2",
+                "node-cron": "^3.0.3",
                 "openai": "^4.68.4",
                 "postmark": "^4.0.5",
                 "ts-node": "^10.9.2",
                 "zod": "^3.23.8"
             },
             "devDependencies": {
-                "@types/express": "^5.0.0"
+                "@types/express": "^5.0.0",
+                "@types/node-cron": "^3.0.11"
             }
         },
         "curator": {
@@ -1792,6 +1794,13 @@
             "dependencies": {
                 "undici-types": "~6.20.0"
             }
+        },
+        "node_modules/@types/node-cron": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+            "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/node-fetch": {
             "version": "2.6.12",
@@ -6021,6 +6030,18 @@
             },
             "optionalDependencies": {
                 "hpagent": "^0.1.2"
+            }
+        },
+        "node_modules/node-cron": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+            "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+            "license": "ISC",
+            "dependencies": {
+                "uuid": "8.3.2"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/node-domexception": {

--- a/supabase/migrations/20250123103504_create_subscribers_table.sql
+++ b/supabase/migrations/20250123103504_create_subscribers_table.sql
@@ -1,6 +1,8 @@
--- creation of the table subscribers
+-- Creation of the Subscribers table
 CREATE TABLE IF NOT EXISTS Subscribers (
-    id SERIAL PRIMARY KEY, -- unique id, auto-incremented
-    user_email VARCHAR(255) UNIQUE NOT NULL, -- unique email of the user, mendatory
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP -- date of subscription, default : nowaday
+    id SERIAL PRIMARY KEY, -- Unique id, auto-incremented
+    user_email VARCHAR(255) NOT NULL, -- Email of the user (remove UNIQUE if duplicate entries are allowed)
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- Date of subscription (defaults to current timestamp)
+    next_newsletter TIMESTAMP DEFAULT CURRENT_TIMESTAMP, -- Next newsletter send date (defaults to now)
+    periodicity INTEGER DEFAULT 604800 -- Interval between newsletters in seconds (default: 604800 seconds = 7 days)
 );


### PR DESCRIPTION
This new feature allows the scheduler to plan and send newsletters as needed, according to a defined periodicity.

For now, the script executed when sending emails is a simple "hello world" in the console to avoid consuming emails in Postmark. However, you can replace it with the actual newsletter-sending script that we have already developed.

The script checks every 10 seconds if there are newsletters to send. If so, it executes the specified script (currently "hello.ts" for testing purposes).

After sending an email, it schedules the next one based on the user's chosen periodicity.

In this example, we plan to send two newsletters at 19:10.
One person wants another newsletter in 5 minutes, and the other in 6 minutes (this demonstrates different periodicity management).

Example in the terminal : 
![image](https://github.com/user-attachments/assets/7d6e25b6-7afb-4b5f-b57f-fc6292f52be7)

Looking at the database after execution : 
![image](https://github.com/user-attachments/assets/5d96f96b-aed2-44f4-9e44-78d0cc582bda)

